### PR TITLE
Fix Permalink on location change

### DIFF
--- a/src/components/MapLocation.js
+++ b/src/components/MapLocation.js
@@ -17,7 +17,7 @@ import mapPositionIcon from '../icons/mapPosition.svg';
 import { MapContext } from '../spatial/components/Map';
 import Mapbox from '../spatial/components/layer/Mapbox';
 import Vector from '../spatial/components/layer/Vector';
-import { setMapLocation, setFormLocation } from '../store/actions';
+import { setMapLocation } from '../store/actions';
 import styles from './MapLocation.module.css';
 
 const getKey = (sl) =>

--- a/src/components/MapLocation.js
+++ b/src/components/MapLocation.js
@@ -17,7 +17,7 @@ import mapPositionIcon from '../icons/mapPosition.svg';
 import { MapContext } from '../spatial/components/Map';
 import Mapbox from '../spatial/components/layer/Mapbox';
 import Vector from '../spatial/components/layer/Vector';
-import { setMapLocation } from '../store/actions';
+import { setMapLocation, setFormLocation } from '../store/actions';
 import styles from './MapLocation.module.css';
 
 const getKey = (sl) =>
@@ -109,6 +109,7 @@ function MapLocation() {
         location.transition = null;
       }
       dispatch(setMapLocation(location, resetFormLocation));
+      dispatch(setFormLocation(location));
       if (isMobile === false && location.forestType) {
         history.push(`/projection${window.location.search}`);
       }

--- a/src/components/MapLocation.js
+++ b/src/components/MapLocation.js
@@ -109,7 +109,6 @@ function MapLocation() {
         location.transition = null;
       }
       dispatch(setMapLocation(location, resetFormLocation));
-      dispatch(setFormLocation(location));
       if (isMobile === false && location.forestType) {
         history.push(`/projection${window.location.search}`);
       }

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -82,6 +82,9 @@ function tree(state = initialState, action) {
       if (mapLocation.forestType) {
         formLocation.forestType = undefined;
       }
+      if (mapLocation.transitionForestType) {
+        formLocation.transitionForestType = undefined;
+      }
       return { ...state, formLocation, mapLocation, projectionMode: 'm' };
     }
     case SET_MAP_VIEW:


### PR DESCRIPTION
Currently the Permalink is not updated when a location is selected on the map, since the formLocation is not updated in redux.

This results in errors in the ProjectionForm, since the Permalink syncs with the form and theerefore may render erroneous content (e.g. when loading a location via the permalink including the flt and/or fltft parameters, these will never be updated and therefore the form will also not update)

Fix: The formLocation is set in the MapLocation component when clicking on the map.