### PR TITLE
Update comparison table layout

### DIFF
--- a/src/components/ForestTypeComparison/lu/ComparisonCell.js
+++ b/src/components/ForestTypeComparison/lu/ComparisonCell.js
@@ -17,7 +17,7 @@ const ComparisonCell = ({
 }) => {
   const isMobile = useIsMobile();
   return (
-    <td className={className || undefined}>
+    <td className={className || undefined} style={{ verticalAlign: 'top' }}>
       <>
         <span style={{ display: 'flex' }}>
           {isMobile && (

--- a/src/components/ForestTypeComparison/lu/ForestTypeTab.js
+++ b/src/components/ForestTypeComparison/lu/ForestTypeTab.js
@@ -34,6 +34,19 @@ ComparedString.propTypes = {
   isLast: PropTypes.bool.isRequired,
 };
 
+const HeaderCell = ({ ...props }) => {
+  const { children } = props;
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <Table.HeaderCell {...props} verticalAlign="top">
+      {children}
+    </Table.HeaderCell>
+  );
+};
+HeaderCell.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+};
+
 const getPioneerTreeTypes = (info, allInfos) => {
   const allTreeTypes = allInfos.reduce((pioneerTypes, current) => {
     const currentPioneersTypes = current.pioneerTreeTypes;
@@ -123,32 +136,16 @@ function ForestTypeTab({ data }) {
       <Table.Body>
         {!isMobile && (
           <Table.Row>
-            <Table.HeaderCell>{t('lu.forestType.general')}</Table.HeaderCell>
+            <HeaderCell>{t('lu.forestType.general')}</HeaderCell>
             {data.map((ft) => (
-              <Table.HeaderCell key={ft.code}>
+              <HeaderCell key={ft.code}>
                 <ForestTypeLink code={ft.code} />
-              </Table.HeaderCell>
+              </HeaderCell>
             ))}
           </Table.Row>
         )}
         <Table.Row>
-          <Table.HeaderCell>
-            {t('lu.forestType.tilleringFirwood')}
-          </Table.HeaderCell>
-          {data.map((ft) => (
-            <ComparisonCell
-              key={ft.code}
-              code={ft.code}
-              hasSameValues={getHasSameValues(ft, data, 'tilleringFirwood')}
-              data={ft.tilleringFirwood}
-              unit="%"
-            />
-          ))}
-        </Table.Row>
-        <Table.Row>
-          <Table.HeaderCell>
-            {t('lu.forestType.tilleringHardwood')}
-          </Table.HeaderCell>
+          <HeaderCell>{t('lu.forestType.tilleringHardwood')}</HeaderCell>
           {data.map((ft) => (
             <ComparisonCell
               key={ft.code}
@@ -188,9 +185,18 @@ function ForestTypeTab({ data }) {
           </tr>
         ))}
         <Table.Row>
-          <Table.HeaderCell>
-            {t('lu.forestType.pioneerTreeTypes')}
-          </Table.HeaderCell>
+          <HeaderCell>{t('lu.forestType.tilleringFirwood')}</HeaderCell>
+          {data.map((ft) => (
+            <ComparisonCell
+              key={ft.code}
+              code={ft.code}
+              hasSameValues={getHasSameValues(ft, data, 'tilleringFirwood')}
+              data={ft.tilleringFirwood}
+            />
+          ))}
+        </Table.Row>
+        <Table.Row>
+          <HeaderCell>{t('lu.forestType.pioneerTreeTypes')}</HeaderCell>
           {data.map((ft) => (
             <ComparisonCell key={ft.code} hasSameValues={false} code={ft.code}>
               {getPioneerTreeTypes(ft, data)}
@@ -198,9 +204,7 @@ function ForestTypeTab({ data }) {
           ))}
         </Table.Row>
         <Table.Row>
-          <Table.HeaderCell>
-            {t('lu.forestType.priority.label')}
-          </Table.HeaderCell>
+          <HeaderCell>{t('lu.forestType.priority.label')}</HeaderCell>
           {data.map((ft) => (
             <ComparisonCell
               key={ft.code}
@@ -213,7 +217,7 @@ function ForestTypeTab({ data }) {
           ))}
         </Table.Row>
         <Table.Row>
-          <Table.HeaderCell>{t('lu.forestType.aptitude')}</Table.HeaderCell>
+          <HeaderCell>{t('lu.forestType.aptitude')}</HeaderCell>
           {data.map((ft, idx, arr) => (
             <ComparisonCell
               code={ft.code}
@@ -224,7 +228,7 @@ function ForestTypeTab({ data }) {
           ))}
         </Table.Row>
         <Table.Row>
-          <Table.HeaderCell>{t('lu.forestType.rejuvDev')}</Table.HeaderCell>
+          <HeaderCell>{t('lu.forestType.rejuvDev')}</HeaderCell>
           {data.map((ft, idx, arr) => (
             <ComparisonCell
               key={ft.code}
@@ -235,7 +239,7 @@ function ForestTypeTab({ data }) {
           ))}
         </Table.Row>
         <Table.Row>
-          <Table.HeaderCell>{t('lu.forestType.care')}</Table.HeaderCell>
+          <HeaderCell>{t('lu.forestType.care')}</HeaderCell>
           {data.map((ft, idx, arr) => (
             <ComparisonCell
               key={ft.code}
@@ -246,9 +250,7 @@ function ForestTypeTab({ data }) {
           ))}
         </Table.Row>
         <Table.Row>
-          <Table.HeaderCell>
-            {t('lu.forestType.heightDispersion')}
-          </Table.HeaderCell>
+          <HeaderCell>{t('lu.forestType.heightDispersion')}</HeaderCell>
           {data.map((ft, idx, arr) => (
             <ComparisonCell
               key={ft.code}
@@ -259,7 +261,7 @@ function ForestTypeTab({ data }) {
           ))}
         </Table.Row>
         <Table.Row>
-          <Table.HeaderCell>{t('lu.forestType.terrain')}</Table.HeaderCell>
+          <HeaderCell>{t('lu.forestType.terrain')}</HeaderCell>
           {data.map((ft) => (
             <ComparisonCell code={ft.code} key={ft.code}>
               <Relief code={ft.code} />
@@ -267,9 +269,7 @@ function ForestTypeTab({ data }) {
           ))}
         </Table.Row>
         <Table.Row>
-          <Table.HeaderCell>
-            {t('forestTypeDiagram.vegetation')}
-          </Table.HeaderCell>
+          <HeaderCell>{t('forestTypeDiagram.vegetation')}</HeaderCell>
           <>
             {data.map((ft, idx, arr) => (
               <ComparisonCell
@@ -282,7 +282,7 @@ function ForestTypeTab({ data }) {
           </>
         </Table.Row>
         <Table.Row>
-          <Table.HeaderCell>{t('lu.forestType.soil.label')}</Table.HeaderCell>
+          <HeaderCell>{t('lu.forestType.soil.label')}</HeaderCell>
           {data.map((ft) => (
             <ComparisonCell key={ft.code} code={ft.code}>
               {getSoilTypes(

--- a/src/components/ForestTypeDescription/lu/DataTable.js
+++ b/src/components/ForestTypeDescription/lu/DataTable.js
@@ -2,39 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Table } from 'semantic-ui-react';
 
-const Icon = ({ value }) => (
-  <div style={{ display: 'flex', alignItems: 'center' }}>
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      height={16}
-      width={16}
-      viewBox="0 0 16 16"
-    >
-      {value === 1 && (
-        <>
-          <line y1={0} y2={16} x1={8} x2={8} stroke="black" strokeWidth={2} />
-          <line y1={8} y2={8} x1={0} x2={16} stroke="black" strokeWidth={2} />
-        </>
-      )}
-      {value === 2 && (
-        <rect
-          height={16}
-          width={16}
-          stroke="black"
-          strokeWidth={2}
-          fill="none"
-        />
-      )}
-      {value === 3 && (
-        <rect height={16} width={16} stroke="black" strokeWidth={2} />
-      )}
-    </svg>
-  </div>
-);
-
-Icon.propTypes = {
-  value: PropTypes.number.isRequired,
-};
+import SoilIcon from '../../SoilIcon';
 
 function DataTable({ data, getLabel }) {
   return (
@@ -58,7 +26,7 @@ function DataTable({ data, getLabel }) {
                           <span style={{ width: '90%', maxWidth: 300 }}>
                             {getLabel(index)}
                           </span>
-                          <Icon value={row} />
+                          <SoilIcon value={row} />
                         </div>
                       </Table.Cell>
                     </Table.Row>,

--- a/src/components/SoilIcon.js
+++ b/src/components/SoilIcon.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const SoilIcon = ({ value, size }) => (
+  <div style={{ display: 'flex', alignItems: 'center' }}>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      height={size}
+      width={size}
+      viewBox={`0 0 ${size} ${size}`}
+    >
+      {value === 1 && (
+        <>
+          <line
+            y1={0}
+            y2={size}
+            x1={size / 2}
+            x2={size / 2}
+            stroke="black"
+            strokeWidth={2}
+          />
+          <line
+            y1={size / 2}
+            y2={size / 2}
+            x1={0}
+            x2={size}
+            stroke="black"
+            strokeWidth={2}
+          />
+        </>
+      )}
+      {value === 2 && (
+        <rect
+          height={size}
+          width={size}
+          stroke="black"
+          strokeWidth={2}
+          fill="none"
+        />
+      )}
+      {value === 3 && (
+        <rect height={size} width={size} stroke="black" strokeWidth={2} />
+      )}
+    </svg>
+  </div>
+);
+
+SoilIcon.propTypes = {
+  value: PropTypes.number.isRequired,
+  size: PropTypes.number,
+};
+
+SoilIcon.defaultProps = {
+  size: 16,
+};
+
+export default SoilIcon;

--- a/src/utils/comparisonUtils.js
+++ b/src/utils/comparisonUtils.js
@@ -10,13 +10,3 @@ export const getStringWithUnit = (data, unit) => {
   }
   return data ? parseString(`${data}${unit || ''}`) : '-';
 };
-const getValueIsSame = (arr1, arr2) =>
-  getStringWithUnit(arr1) === getStringWithUnit(arr2) &&
-  getStringWithUnit(arr1) !== '-';
-
-export const getHasSameValues = (currentInfo, infoArray, field) =>
-  infoArray.some(
-    (ft) =>
-      currentInfo.code !== ft.code &&
-      getValueIsSame(currentInfo[field], ft[field]),
-  );

--- a/src/utils/comparisonUtils.js
+++ b/src/utils/comparisonUtils.js
@@ -5,7 +5,7 @@ export const parseString = (str) => parse(str.slice().replace(/\\n/g, '<br>'));
 export const getStringWithUnit = (data, unit) => {
   if (Array.isArray(data)) {
     return data.every((val) => val !== null && val !== undefined)
-      ? `${data.join('-')}${unit}`
+      ? `${data.join(' - ')}${unit || ''}`
       : '-';
   }
   return data ? parseString(`${data}${unit || ''}`) : '-';


### PR DESCRIPTION
Updates:
- Removed all isSame styles (bold & blue color texts)
- Made soil types grid-like with icon
- vertically aligened all table cell content to top
- Moved tillering firwood down to after tillering tree types
- Added spaces for interval values for readability (e.g. 20 - 30%)