### PR TITLE
Fix projection tree list

### DIFF
--- a/lib/src/list.js
+++ b/lib/src/list.js
@@ -53,27 +53,28 @@ function list(location = {}, mergeLevel4 = false) {
       throw new Error(`${transitionForestType} is not valid`);
     }
 
+    const [lists0, lists1, lists2, lists3] = lists;
     const transitionLists = getRecommendations(transitionForestType);
 
     lists[0] = union(
-      intersection(lists[0], transitionLists[0]),
-      intersection(lists[0], transitionLists[1]),
+      intersection(lists0, transitionLists[0]),
+      intersection(lists0, transitionLists[1]),
     );
 
     lists[1] = union(
-      intersection(lists[0], transitionLists[2]),
-      intersection(lists[1], transitionLists[0]),
-      intersection(lists[1], transitionLists[1]),
-      intersection(lists[1], transitionLists[2]),
-      intersection(lists[2], transitionLists[0]),
+      intersection(lists0, transitionLists[2]),
+      intersection(lists1, transitionLists[0]),
+      intersection(lists1, transitionLists[1]),
+      intersection(lists1, transitionLists[2]),
+      intersection(lists2, transitionLists[0]),
     );
 
     lists[2] = union(
-      intersection(lists[2], transitionLists[1]),
-      intersection(lists[2], transitionLists[2]),
+      intersection(lists2, transitionLists[1]),
+      intersection(lists2, transitionLists[2]),
     );
 
-    lists[3] = union(lists[3], transitionLists[3]);
+    lists[3] = union(lists3, transitionLists[3]);
   }
 
   if (mergeLevel4) {


### PR DESCRIPTION
Issue: When intersecting/unifying the lists with the transition lists, lists[0] was overwritten and then used when overwriting lists[1], losing the reference to the original tree types in lists[0].

Solution: The lists are destructured and put into variables before the overwriting.