### PR TITLE
Fix ForestTypeModal Stacking

### DIFF
--- a/src/components/LocationResult.js
+++ b/src/components/LocationResult.js
@@ -9,7 +9,6 @@ import { info } from '@geops/tree-lib';
 import Button from './Button';
 import Ecogram from './Ecogram';
 import HelpModal from './HelpModal';
-import ForestTypeModal from './ForestTypeModal';
 import { setFormLocation } from '../store/actions';
 import styles from './LocationResult.module.css';
 
@@ -71,7 +70,6 @@ function LocationResult() {
                   const onClick = () => selectForestType(ftCode);
                   return (
                     <List.Item key={ftCode} className={styles.listitem}>
-                      <ForestTypeModal data={ftInfo} />
                       <Button
                         active
                         compact

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -1,3 +1,5 @@
+import translation from '../i18n/resources/de/translation.json';
+
 export const SET_FORM_LOCATION = 'SET_FORM_LOCATION';
 export const SET_LATIN_ACTIVE = 'SET_LATIN_ACTIVE';
 export const SET_LOCATION_RESULT = 'SET_LOCATION_RESULT';
@@ -60,7 +62,12 @@ export function setWelcomeModal(open) {
 }
 
 export function setActiveProfile(activeProfile) {
-  return { type: SET_ACTIVE_PROFILE, activeProfile };
+  return {
+    type: SET_ACTIVE_PROFILE,
+    activeProfile: Object.keys(translation.profiles).includes(activeProfile)
+      ? activeProfile
+      : 'ch',
+  };
 }
 
 export function setForestTypeComparison(


### PR DESCRIPTION
When loading the ForestTypeModal while a location result is loaded (e.g. via the Permalink or the Ecogram), an array.map function causes multiple ForestTypeModals to render. The render function in LocationResult was removed.

A further fix prevents the app from crashing if a non-existent profile is loaded (e.g. via the Permalink). Now the app defaults to ch in case the specified profile isn't found