### PR TITLE
Read transitionAltitudinalZone from tiles

### DIFF
--- a/lib/data/sql/V2__create_spatial_tables.sql
+++ b/lib/data/sql/V2__create_spatial_tables.sql
@@ -5,7 +5,7 @@ CREATE TABLE "altitudinal_zones_1995" (gid serial, "hs_de" varchar(200),
                                                            "hs_fr" varchar(200),
                                                                    "hs_it" varchar(200),
                                                                            "hs_en" varchar(200),
-                                                                                   "code" int8, "subcode" int8);
+                                                                                   "code" varchar(10), "subcode" varchar(10));
 
 
 ALTER TABLE "altitudinal_zones_1995" ADD PRIMARY KEY (gid);
@@ -20,7 +20,7 @@ CREATE TABLE "altitudinal_zones_2085_dry" (gid serial, "hs_de" varchar(200),
                                                                "hs_fr" varchar(200),
                                                                        "hs_it" varchar(200),
                                                                                "hs_en" varchar(200),
-                                                                                       "code" int8, "subcode" int8);
+                                                                                       "code" varchar(10), "subcode" varchar(10));
 
 
 ALTER TABLE "altitudinal_zones_2085_dry" ADD PRIMARY KEY (gid);
@@ -36,7 +36,7 @@ CREATE TABLE "altitudinal_zones_2085_less_dry" (gid serial, "hs_de" varchar(200)
                                                                     "hs_fr" varchar(200),
                                                                             "hs_it" varchar(200),
                                                                                     "hs_en" varchar(200),
-                                                                                            "code" int8, "subcode" int8);
+                                                                                            "code" varchar(10), "subcode" varchar(10));
 
 
 ALTER TABLE "altitudinal_zones_2085_less_dry" ADD PRIMARY KEY (gid);

--- a/lib/data/sql/V3__create_types.sql
+++ b/lib/data/sql/V3__create_types.sql
@@ -204,20 +204,22 @@ VALUES ('',
 CREATE TABLE altitudinal_zone_meta (source TEXT, de TEXT, fr TEXT, nais TEXT, code TEXT, zh TEXT, id SERIAL);
 
 
-INSERT INTO altitudinal_zone_meta (source, de, fr, nais, code)
+INSERT INTO altitudinal_zone_meta (source, de, fr, nais, code, zh)
 VALUES ('mediterran',
         'collin-mediterran',
         'collinéen à méditerranéen',
         '01C',
-        '0');
+        '0',
+        'med');
 
 
-INSERT INTO altitudinal_zone_meta (source, de, fr, nais, code)
+INSERT INTO altitudinal_zone_meta (source, de, fr, nais, code, zh)
 VALUES ('hyperinsubrisch',
         'hyperinsubrisch',
         'hyperinsubrique',
         'HY',
-        '10');
+        '10',
+        'hy');
 
 
 INSERT INTO altitudinal_zone_meta (source, de, fr, nais, code, zh)
@@ -229,12 +231,13 @@ VALUES ('collin',
         'co');
 
 
-INSERT INTO altitudinal_zone_meta (source, de, fr, nais, code)
+INSERT INTO altitudinal_zone_meta (source, de, fr, nais, code, zh)
 VALUES ('collin mit Buche',
         'collin mit Buche',
         'collinéen avec hêtre',
         'CB',
-        '30');
+        '30',
+        'cb');
 
 
 INSERT INTO altitudinal_zone_meta (source, de, fr, nais, code, zh)
@@ -264,12 +267,13 @@ VALUES ('obermontan',
         'om');
 
 
-INSERT INTO altitudinal_zone_meta (source, de, fr, nais, code)
+INSERT INTO altitudinal_zone_meta (source, de, fr, nais, code, zh)
 VALUES ('unter- & obermontan',
         'unter- & obermontan',
         'montagnard inférieur & supérieur',
         'UMOM',
-        '70');
+        '70',
+        'umom');
 
 
 INSERT INTO altitudinal_zone_meta (source, de, fr, nais, code, zh)
@@ -281,20 +285,22 @@ VALUES ('hochmontan',
         'hm');
 
 
-INSERT INTO altitudinal_zone_meta (source, de, fr, nais, code)
+INSERT INTO altitudinal_zone_meta (source, de, fr, nais, code, zh)
 VALUES ('subalpin',
         'subalpin',
         'subalpin',
         'SA',
-        '90');
+        '90',
+        'sa');
 
 
-INSERT INTO altitudinal_zone_meta (source, de, fr, nais, code)
+INSERT INTO altitudinal_zone_meta (source, de, fr, nais, code, zh)
 VALUES ('obersubalpin',
         'obersubalpin',
         'subalpin supérieur',
         'OSA',
-        '100');
+        '100',
+        'osa');
 
 ----------------------------------------------
 -- foresttype

--- a/lib/data/sql/V8__export_spatial.sql
+++ b/lib/data/sql/V8__export_spatial.sql
@@ -36,7 +36,7 @@ WITH altitudinal_zones_cantonal AS
                   END AS code
               FROM (SELECT * FROM forest_types_ju) ju
                 LEFT JOIN altitudinal_zone_meta meta ON ju.hs1 = meta.zh
-                LEFT JOIN altitudinal_zone_meta meta_ue ON ju.hsue = meta.zh
+                LEFT JOIN altitudinal_zone_meta meta_ue ON ju.hsue = meta_ue.zh
                 WHERE meta.code IS NOT NULL
                 GROUP BY meta.code, meta_ue.code)
        )foo )

--- a/lib/data/sql/V8__export_spatial.sql
+++ b/lib/data/sql/V8__export_spatial.sql
@@ -41,11 +41,11 @@ WITH altitudinal_zones_cantonal AS
                 GROUP BY meta.code, meta_ue.code)
        )foo )
 
-SELECT (code::TEXT || subcode::TEXT)::integer AS code,
+SELECT (code::TEXT || subcode::TEXT)::text AS code,
        ST_Transform(ST_Difference(geom, (SELECT ST_Union(geom) FROM altitudinal_zones_cantonal)), 3857) AS geometry
 FROM altitudinal_zones_1995
 UNION
-SELECT azc.code::integer,
+SELECT azc.code::text,
        ST_Transform(azc.geom, 3857) AS geometry
 FROM altitudinal_zones_cantonal azc;
 

--- a/lib/data/sql/V8__export_spatial.sql
+++ b/lib/data/sql/V8__export_spatial.sql
@@ -54,7 +54,7 @@ FROM altitudinal_zones_cantonal azc;
 -- altitudinal_zones_2085_dry
 
 CREATE VIEW altitudinal_zones_2085_dry_export AS
-SELECT (code::TEXT || subcode::TEXT)::INT AS code,
+SELECT (code::TEXT || subcode::TEXT)::text AS code,
        ST_Transform(geom, 3857) AS geometry
 FROM altitudinal_zones_2085_dry;
 
@@ -63,7 +63,7 @@ FROM altitudinal_zones_2085_dry;
 -- altitudinal_zones_2085_less_dry
 
 CREATE VIEW altitudinal_zones_2085_less_dry_export AS
-SELECT (code::TEXT || subcode::TEXT)::INT AS code,
+SELECT (code::TEXT || subcode::TEXT)::text AS code,
        ST_Transform(geom, 3857) AS geometry
 FROM altitudinal_zones_2085_less_dry;
 

--- a/lib/data/types.json
+++ b/lib/data/types.json
@@ -10,14 +10,14 @@
       { "de": "nicht relevant", "fr": "pas important", "code": "unknown" }
     ],
     "relief": [
-      { "de": "normal", "fr": "normal", "code": "normal" },
-      { "de": "nicht relevant", "fr": "pas important", "code": "unknown" },
-      { "de": "Kuppenlage", "fr": "sur une butte", "code": "kup" },
       {
         "de": "Hang- und Muldenlage",
         "fr": "en pente ou dans une dépression",
         "code": "h_and_m"
-      }
+      },
+      { "de": "normal", "fr": "normal", "code": "normal" },
+      { "de": "nicht relevant", "fr": "pas important", "code": "unknown" },
+      { "de": "Kuppenlage", "fr": "sur une butte", "code": "kup" }
     ],
     "bushType": [
       {

--- a/src/components/MapLocation.js
+++ b/src/components/MapLocation.js
@@ -108,7 +108,6 @@ function MapLocation() {
       iconFeature.getGeometry().setCoordinates(coordinate);
       const pixel = map.getPixelFromCoordinate(coordinate);
       const features = map.getFeaturesAtPixel(pixel) || [];
-      console.log(features);
       let location = features
         .filter((feature) => feature.properties?.code !== undefined)
         .reduce(featuresToLocation, { forestTypes: [] });

--- a/src/components/MapLocation.js
+++ b/src/components/MapLocation.js
@@ -108,6 +108,7 @@ function MapLocation() {
       iconFeature.getGeometry().setCoordinates(coordinate);
       const pixel = map.getPixelFromCoordinate(coordinate);
       const features = map.getFeaturesAtPixel(pixel) || [];
+      console.log(features);
       let location = features
         .filter((feature) => feature.properties?.code !== undefined)
         .reduce(featuresToLocation, { forestTypes: [] });

--- a/src/components/ProjectionForm.js
+++ b/src/components/ProjectionForm.js
@@ -176,7 +176,7 @@ function ProjectionForm() {
             <Dropdown
               className={styles.forestType}
               data-cypress="projectionFormTransitionForestType"
-              clearable
+              clearable={!!formLocation.transitionForestType}
               label={t('forestType.transition')}
               options={(options.transitionForestType || options.forestType).map(
                 getDropdownOptions('forestType', i18n.language, dispatch, true),
@@ -191,7 +191,7 @@ function ProjectionForm() {
               value={getValue('transitionForestType')}
             />
             <Dropdown
-              clearable
+              clearable={!!formLocation.transitionAltitudinalZone}
               data-cypress="projectionFormTransitionAltitudinalZone"
               label={t('altitudinalZone.transition')}
               options={options.altitudinalZone.map(
@@ -202,10 +202,7 @@ function ProjectionForm() {
               }}
               onBlur={deactivateField}
               onFocus={() => activateField('transitionAltitudinalZone')}
-              value={
-                getValue('altitudinalZone', { transition: true }) ||
-                getValue('altitudinalZone')
-              }
+              value={getValue('altitudinalZone', { transition: true })}
             />
           </Segment>
         )}

--- a/src/store/enhancers/projection.js
+++ b/src/store/enhancers/projection.js
@@ -45,6 +45,9 @@ const projection = (store) => (next) => (action) => {
     location.transition = formLocation.transition || mapLocation.transition;
     location.transitionForestType =
       formLocation.transitionForestType || mapLocation.transitionForestType;
+    location.transitionAltitudinalZone =
+      formLocation.transitionAltitudinalZone ||
+      location.transitionAltitudinalZone;
     if (hochmontanAltitudinalZones.includes(location.altitudinalZone)) {
       if (projectionMode === 'm' || !formLocation.silverFirArea) {
         location.silverFirArea = location.altitudinalZone.slice(1);


### PR DESCRIPTION
To be consistent with the forest types vTiles, the altitudinal_zones 1995 data now handles transiton altitudinal zones by putting them in brackets after the main zone

The Recommendation form adjusts the altitudinal zone on transition locations on load