### PR TITLE
fix(recommendation): add dominant transition tree types to Weitere Baumarten

### DIFF
--- a/lib/src/list.mjs
+++ b/lib/src/list.mjs
@@ -1,5 +1,6 @@
 import intersection from 'lodash.intersection';
 import union from 'lodash.union';
+import difference from 'lodash.difference';
 
 import recommendations from '../data/recommendations.json';
 import utils from './utils.mjs';
@@ -57,6 +58,7 @@ function list(location = {}, mergeLevel4 = false) {
     );
 
     lists[2] = union(
+      difference(transitionLists[0], lists.flat()),
       intersection(lists2, transitionLists[1]),
       intersection(lists2, transitionLists[2]),
     );

--- a/lib/test/list.test.js
+++ b/lib/test/list.test.js
@@ -35,5 +35,5 @@ describe('valid results', () => {
   test('valid forestType and transitionForestType', () =>
     expect(
       list({ forestType: '60', transitionForestType: '55 collin' }),
-    ).toStrictEqual([[], [402300], [60400, 363700], [9500]]));
+    ).toStrictEqual([[], [402300], [60400, 335900, 363700], [9500]]));
 });


### PR DESCRIPTION
Dominant tree types must be categorised into "Weitere Baumarten" in the Recommendation panels.
tree-lib has been updated